### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
         <dep.codehaus-jackson.version>1.9.2</dep.codehaus-jackson.version>
         <dep.commons-codec.version>1.8</dep.commons-codec.version>
         <dep.commons-cli.version>1.2</dep.commons-cli.version>
-        <dep.commons-collections.version>3.2.1</dep.commons-collections.version>
+        <dep.commons-collections.version>3.2.2</dep.commons-collections.version>
         <dep.commons-configuration.version>1.6</dep.commons-configuration.version>
         <dep.commons-httpclient.version>3.0.1</dep.commons-httpclient.version>
         <dep.commons-logging.version>1.1.1</dep.commons-logging.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
